### PR TITLE
Add a SHA1 hash header to the FCM request

### DIFF
--- a/Auth/fcm_receiver.py
+++ b/Auth/fcm_receiver.py
@@ -29,12 +29,18 @@ class FcmReceiver:
         api_key = "AIzaSyD_gko3P392v6how2H7UpdeXQ0v2HLettc"
         message_sender_id = "289722593072"
 
+        # APK signing certificate SHA1
+        android_cert_sha1 = "38918a453d07199354f8b19af05ec6562ced5788"
+        bundle_id = "com.google.android.apps.adm"
+
         fcm_config = FcmRegisterConfig(
             project_id=project_id,
             app_id=app_id,
             api_key=api_key,
             messaging_sender_id=message_sender_id,
-            bundle_id="com.google.android.apps.adm",
+            bundle_id=bundle_id,
+            android_package=bundle_id,
+            android_cert_sha1=android_cert_sha1
         )
 
         self.credentials = get_cached_value('fcm_credentials')


### PR DESCRIPTION
This change is to circumvent the [Error API_KEY_ANDROID_APP_BLOCKED](https://github.com/leonboe1/GoogleFindMyTools/issues/90) issue.
It appears Google has added SHA1 restrictions for Firebase authentication. This error can be avoided by adding the following headers to the request within `fcmregister.py`:
- `X-Android-Package`: `com.google.android.apps.adm` (Package ID)
- `X-Android-Cert`: `38918a453d07199354f8b19af05ec6562ced5788` (SHA1 hash of APK certificate fingerprints)

The SHA1 hash can be confirmed from pages like the following:
https://www.apkmirror.com/apk/google-inc/find-my-device/googles-find-hub-find-my-device-3-1-485-2-release/googles-find-hub-find-my-device-3-1-485-2-2-android-apk-download/#safeDownload