### PR TITLE
Add Docker/noVNC wrapper for interactive Google login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.idea
 /DULT/OwnerLookup/Results
 /Auth/secrets.json
+/data/secrets.json
 /example_data.json
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,swiftpackagemanager,objective-c
@@ -186,3 +187,4 @@ venv/
 *** Python cache***
 *.pyc  
 # End of https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,swiftpackagemanager,objective-c
+data/secrets.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM selenium/standalone-chrome:latest
+
+USER root
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN mkdir -p /app/Auth && chown -R seluser:seluser /app
+RUN chown -R seluser:seluser /home/seluser
+
+COPY docker-entrypoint.sh /opt/bin/gfm-entrypoint.sh
+RUN chmod +x /opt/bin/gfm-entrypoint.sh
+
+USER seluser
+
+ENTRYPOINT ["/opt/bin/gfm-entrypoint.sh"]

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,89 @@
+# MANUAL.md — Running GoogleFindMyTools via Docker
+
+Docker wrapper around [GoogleFindMyTools](https://github.com/leonboe1/GoogleFindMyTools). Handles Chrome + Python deps inside a container; exposes the one-time Google login through a browser-based VNC viewer since the tool needs a real Chrome GUI session to authenticate (not a simple token/link flow).
+
+**Status:** verified end-to-end — real Google login through noVNC, `oauth_token` captured, `main.py` lists devices.
+
+## Prerequisites
+
+- Docker + Docker Compose installed on host.
+- Nothing else — no local Python, no local Chrome needed.
+
+## First run (Google login required)
+
+1. From the repo directory:
+   ```bash
+   cd /home/sandor/claude/googlefindmy/GoogleFindMyTools
+   docker compose up
+   ```
+   Run in the **foreground** (no `-d`) — the script asks for keyboard input.
+
+2. Wait for this line in the terminal:
+   ```
+   [AuthFlow] Press Enter to continue...
+   ```
+   Press **Enter**.
+
+3. Open **http://localhost:7900** in your normal browser. Password: `secret`.
+   You'll see a live view of Chrome running inside the container.
+
+4. In that noVNC window, log into your Google account as you normally would (2FA etc. all work same as any browser).
+
+5. Once login completes, the terminal will print `[AuthFlow] Retrieved Account Token successfully.` and continue — `main.py` proceeds to list your Find My Device trackers/Android devices.
+
+6. Your session is cached to `data/secrets.json` on the host. You will not need to repeat the browser login on future runs unless that file is deleted or Google invalidates the session.
+
+## Normal (already authenticated) runs
+
+```bash
+docker compose up
+```
+Same command — if `data/secrets.json` already has valid tokens, it skips straight to listing devices; no browser step needed. You can ignore the noVNC link at that point.
+
+## Using the tool once it's running
+
+`main.py` is interactive:
+- Type a device number + Enter → prints/decrypts that device's last known location.
+- Type `r` + Enter → register a new ESP32/Zephyr-based tracker (follow on-screen instructions).
+- `Ctrl+C` to quit.
+
+## Stopping
+
+```bash
+docker compose down
+```
+Stops and removes the container. `data/secrets.json` (your login) survives since it's a host-mounted file, not inside the container.
+
+## Rebuilding after a repo/code update
+
+```bash
+git pull
+docker compose build
+docker compose up
+```
+
+## Files in this setup
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Builds the app image on top of `selenium/standalone-chrome` (bundles Chrome + virtual display + noVNC). |
+| `docker-entrypoint.sh` | Starts the virtual display stack, then runs `python3 main.py` in the foreground. |
+| `docker-compose.yml` | One-command build+run: opens stdin/tty, publishes noVNC port 7900, mounts `data/secrets.json`. |
+| `data/secrets.json` | Your cached Google auth tokens. Gitignored — never commit this file. Delete it to force a fresh login. |
+
+## Troubleshooting
+
+- **Stuck with no prompt / can't type anything:** you probably ran with `docker compose up -d` (detached). Run it in the foreground instead.
+- **noVNC page won't load:** give the container a few seconds to boot; check `docker compose logs` for `[entrypoint] Display ready.`
+- **Forgot the noVNC password:** it's `secret` — a fixed default from the base image, not something this setup configures.
+- **Want a completely fresh login:** stop the container, delete `data/secrets.json`, recreate it as an empty JSON file (`echo '{}' > data/secrets.json`), then `docker compose up` again.
+- **Permission errors writing `secrets.json`:** make sure `data/secrets.json` exists on the host *before* starting the container and is writable (`chmod 666 data/secrets.json`) — Docker will otherwise create it as a directory or with mismatched ownership.
+
+## Known limitation
+
+The Google login step itself must be done by a human through the noVNC browser window — there's no way to script or automate that part (nor should there be, since it's your real Google account credentials).
+
+## Fixes baked into this image
+
+- **Home dir ownership:** the base `selenium/standalone-chrome` image leaves `/home/seluser/.local` owned by `root`, which broke `undetected_chromedriver`'s cache dir (`PermissionError`). `Dockerfile` chowns `/home/seluser` to `seluser` at build time.
+- **ChromeDriver/Chrome version mismatch:** `undetected_chromedriver`'s `version_main=None` auto-detection didn't reliably match the image's bundled Chrome, so it fetched the latest chromedriver instead of the one matching the installed Chrome (`SessionNotCreatedException`). `chrome_driver.py` now reads the installed Chrome's version via `google-chrome --version` and pins `version_main` explicitly.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Currently, it is possible to query Find My Device / Find Hub trackers and Androi
 - Install the latest version of Google Chrome: https://www.google.com/chrome/
 - Start the program by running [main.py](main.py): `python main.py` or `python3 main.py`
 
+### Docker (alternative — no local Python/Chrome needed)
+
+Runs the tool in a container with Chrome + noVNC bundled, so the one-time Google login happens in a browser tab instead of a local Chrome install. See [MANUAL.md](MANUAL.md) for full details/troubleshooting; quick start:
+
+```bash
+git clone https://github.com/leonboe1/GoogleFindMyTools.git
+cd GoogleFindMyTools
+docker compose up
+```
+
+- Wait for `[AuthFlow] Press Enter to continue...` in the terminal, press **Enter**.
+- Open `http://localhost:7900` in your browser (password: `secret`) and log into your Google account there.
+- Once login completes, `main.py` proceeds to list your devices. Auth is cached to `data/secrets.json` on the host, so future runs (`docker compose up`) skip the browser step.
+
 ### Authentication
 
 On the first run, an authentication sequence is executed, which requires a computer with access to Google Chrome.

--- a/chrome_driver.py
+++ b/chrome_driver.py
@@ -4,9 +4,27 @@
 #
 import undetected_chromedriver as uc
 import os
+import re
 import shutil
+import subprocess
 import platform
 import time
+
+def get_chrome_major_version(chrome_path=None):
+    """Return installed Chrome's major version, or None if it can't be determined."""
+    candidates = [chrome_path] if chrome_path else []
+    candidates += ["google-chrome", "/usr/bin/google-chrome", "chromium", "chromium-browser"]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            output = subprocess.check_output([candidate, "--version"], stderr=subprocess.STDOUT, text=True)
+        except Exception:
+            continue
+        match = re.search(r"(\d+)\.\d+\.\d+\.\d+", output)
+        if match:
+            return int(match.group(1))
+    return None
 
 def find_chrome():
     """Find Chrome executable using known paths and system commands."""
@@ -58,7 +76,8 @@ def create_driver():
             pass
             
         chrome_options = get_options()
-        driver = uc.Chrome(options=chrome_options, version_main=None)
+        version_main = get_chrome_major_version()
+        driver = uc.Chrome(options=chrome_options, version_main=version_main)
         print("[ChromeDriver] Installed and browser started.")
         return driver
     except Exception as e:
@@ -69,20 +88,22 @@ def create_driver():
             chrome_options = get_options()
             chrome_options.binary_location = chrome_path
             try:
-                driver = uc.Chrome(options=chrome_options, version_main=None)
+                version_main = get_chrome_major_version(chrome_path)
+                driver = uc.Chrome(options=chrome_options, version_main=version_main)
                 print(f"[ChromeDriver] ChromeDriver started using {chrome_path}")
                 return driver
             except Exception as e:
                 print(f"[ChromeDriver] ChromeDriver failed using path {chrome_path}: {e}")
         else:
             print("[ChromeDriver] No Chrome executable found in known paths.")
-        
+
         # Final fallback - try headless mode
         print("[ChromeDriver] Trying headless mode as last resort...")
         try:
             chrome_options = get_options()
             chrome_options.add_argument("--headless")
-            driver = uc.Chrome(options=chrome_options, version_main=None)
+            version_main = get_chrome_major_version(chrome_path)
+            driver = uc.Chrome(options=chrome_options, version_main=version_main)
             print("[ChromeDriver] Started in headless mode successfully.")
             return driver
         except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  googlefindmy:
+    build: .
+    stdin_open: true
+    tty: true
+    shm_size: "2g"
+    ports:
+      - "7900:7900"   # noVNC web viewer, password: secret
+    volumes:
+      - ./data/secrets.json:/app/Auth/secrets.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+"${VENV_PATH}/bin/supervisord" --configuration /etc/supervisord.conf &
+SUPERVISOR_PID=$!
+
+function shutdown {
+  kill -s SIGTERM "${SUPERVISOR_PID}" 2>/dev/null || true
+  wait "${SUPERVISOR_PID}" 2>/dev/null || true
+}
+trap shutdown SIGTERM SIGINT
+
+echo "[entrypoint] Waiting for X display ${DISPLAY} to come up..."
+for i in $(seq 1 30); do
+  if xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1; then
+    echo "[entrypoint] Display ready."
+    break
+  fi
+  sleep 1
+done
+
+echo "[entrypoint] Open http://localhost:7900 (password: secret) in your browser to see Chrome."
+cd /app
+python3 main.py
+
+shutdown


### PR DESCRIPTION
## Summary
- Adds a Docker setup (`Dockerfile`, `docker-compose.yml`, `docker-entrypoint.sh`) that runs the app on top of `selenium/standalone-chrome`, exposing the one-time Google login through noVNC (`localhost:7900`) since `Auth/auth_flow.py` needs a real Chrome GUI session (waits on an `oauth_token` cookie), not a token/device-code flow.
- Fixes two issues found running inside that base image, in `chrome_driver.py`:
  - `/home/seluser/.local` is root-owned in the base image, breaking `undetected_chromedriver`'s cache dir with a `PermissionError` (fixed in `Dockerfile` with an extra `chown`).
  - `version_main=None` auto-detection in `undetected_chromedriver` didn't reliably match the bundled Chrome version, causing `SessionNotCreatedException` (chromedriver latest vs. installed Chrome mismatch). Now explicitly detects the installed Chrome version via `google-chrome --version` and pins `version_main`.
- Adds `MANUAL.md` documenting the Docker setup, first-run login flow, and troubleshooting.
- `.gitignore`: excludes `data/secrets.json` (the host-mounted auth cache for the Docker setup).

## Test plan
- [x] `docker compose build` — image builds clean.
- [x] `docker compose up` — Selenium Grid + Xvfb + noVNC come up, `main.py` reaches the `[AuthFlow]` prompt.
- [x] Completed a real Google login through noVNC end-to-end — `oauth_token` captured, `main.py` proceeded to list devices.
- [x] Verified `data/secrets.json` persists across container restarts (no re-login needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)