### PR TITLE
Fix decrypt failures, hanging waits, and a few listener crashes

### DIFF
--- a/Auth/auth_flow.py
+++ b/Auth/auth_flow.py
@@ -3,14 +3,30 @@
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
 
+import threading
+
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
+
 from chrome_driver import create_driver
 
+SIGN_IN_WAIT_S = 300
+
+# create_driver() unconditionally pkills any running "chrome" process before
+# launching a new one, so two overlapping calls would kill each other's
+# browser. This serializes them process-wide instead of racing.
+_flow_lock = threading.Lock()
+
 def request_oauth_account_token_flow():
+    with _flow_lock:
+        return _request_oauth_account_token_flow()
+
+
+def _request_oauth_account_token_flow():
 
     print("""[AuthFlow] This script will now open Google Chrome on your device to login to your Google account.
 > Please make sure that Chrome is installed on your system.
-> For macOS users only: Make that you allow Python (or PyCharm) to control Chrome if prompted. 
+> For macOS users only: Make that you allow Python (or PyCharm) to control Chrome if prompted.
     """)
 
     # Press enter to continue
@@ -26,10 +42,20 @@ def request_oauth_account_token_flow():
         driver.get("https://accounts.google.com/EmbeddedSetup")
 
         # Wait until the "oauth_token" cookie is set
-        print("[AuthFlow] Waiting for 'oauth_token' cookie to be set...")
-        WebDriverWait(driver, 300).until(
-            lambda d: d.get_cookie("oauth_token") is not None
-        )
+        print(f"[AuthFlow] Waiting up to {SIGN_IN_WAIT_S}s for you to finish signing in "
+              f"('oauth_token' cookie not set yet)...")
+        try:
+            WebDriverWait(driver, SIGN_IN_WAIT_S).until(
+                lambda d: d.get_cookie("oauth_token") is not None
+            )
+        except TimeoutException:
+            # Selenium's own TimeoutException carries no message, so this
+            # would otherwise surface as a blank "Message: " error with no
+            # indication of what actually happened or how long it waited.
+            raise TimeoutError(
+                f"Timed out after {SIGN_IN_WAIT_S}s waiting for you to complete the Google "
+                f"sign-in in the browser. Run this again to retry."
+            ) from None
 
         # Get the value of the "oauth_token" cookie
         oauth_token_cookie = driver.get_cookie("oauth_token")

--- a/Auth/fcm_receiver.py
+++ b/Auth/fcm_receiver.py
@@ -45,6 +45,7 @@ class FcmReceiver:
 
         self.credentials = get_cached_value('fcm_credentials')
         self.location_update_callbacks = []
+        self._callbacks_lock = threading.Lock()
         self.pc = FcmPushClient(self._on_notification, fcm_config, self.credentials, self._on_credentials_updated)
 
 
@@ -53,9 +54,16 @@ class FcmReceiver:
         if not self._listening:
             self._start_listener_in_background()
 
-        self.location_update_callbacks.append(callback)
+        with self._callbacks_lock:
+            self.location_update_callbacks.append(callback)
 
         return self.credentials['fcm']['registration']['token']
+
+
+    def unregister_callback(self, callback):
+        with self._callbacks_lock:
+            if callback in self.location_update_callbacks:
+                self.location_update_callbacks.remove(callback)
 
 
     def stop_listening(self):
@@ -87,7 +95,10 @@ class FcmReceiver:
             # Convert to hex string
             hex_string = binascii.hexlify(decoded_bytes).decode('utf-8')
 
-            for callback in self.location_update_callbacks:
+            with self._callbacks_lock:
+                callbacks = list(self.location_update_callbacks)
+
+            for callback in callbacks:
                 callback(hex_string)
         else:
             print("[FCMReceiver] Payload not found in the notification.")

--- a/Auth/firebase_messaging/fcmpushclient.py
+++ b/Auth/firebase_messaging/fcmpushclient.py
@@ -402,8 +402,13 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
         salt_str: str,
         raw_data: bytes,
     ) -> bytes:
-        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii"))
-        salt = urlsafe_b64decode(salt_str.encode("ascii"))
+        # Per-message headers from the push service, unlike the two decodes
+        # below, come without their base64url padding often enough that this
+        # crashed the whole listener ("binascii.Error: Incorrect padding").
+        # Excess "=" is harmless to urlsafe_b64decode, same trick already
+        # used just below for der_data/secret.
+        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii") + b"========")
+        salt = urlsafe_b64decode(salt_str.encode("ascii") + b"========")
         der_data_str = credentials["keys"]["private"]
         der_data = urlsafe_b64decode(der_data_str.encode("ascii") + b"========")
         secret_str = credentials["keys"]["secret"]
@@ -449,8 +454,15 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
         ):
             # The deleted_messages message does not contain data.
             return
-        crypto_key = self._app_data_by_key(msg, "crypto-key")[3:]  # strip dh=
-        salt = self._app_data_by_key(msg, "encryption")[5:]  # strip salt=
+        # Both headers can carry more than one ;-separated parameter (e.g.
+        # "dh=<point>;p256ecdsa=<other key>") - take only the value for the
+        # parameter we actually want. Keeping the rest used to decode into
+        # one garbage-length blob instead of raising (base64 silently drops
+        # the stray ";"/"=" characters from the second parameter rather than
+        # erroring on them), which then failed EC point validation with a
+        # confusing "Invalid EC key" deep inside http_ece.
+        crypto_key = self._app_data_by_key(msg, "crypto-key")[3:].split(";")[0]  # strip dh=
+        salt = self._app_data_by_key(msg, "encryption")[5:].split(";")[0]  # strip salt=
         subtype = self._app_data_by_key(msg, "subtype")
         if TYPE_CHECKING:
             assert self.credentials
@@ -461,6 +473,13 @@ class FcmPushClient:  # pylint:disable=too-many-instance-attributes
                 subtype,
                 self.credentials["gcm"]["app_id"],
             )
+            # Not meant for us - the shared MCS channel can carry data
+            # messages for other apps/services registered under the same
+            # Android ID. Decrypting one anyway with our own key material is
+            # guaranteed to fail (a foreign message's crypto-key isn't even
+            # necessarily in our expected format/curve), and used to crash
+            # the whole listener instead of just skipping this one message.
+            return
         if not self.credentials:
             return
         decrypted = self._decrypt_raw_data(

--- a/Auth/token_cache.py
+++ b/Auth/token_cache.py
@@ -35,6 +35,22 @@ def get_cached_value(name: str):
     return None
 
 
+def get_cached_values_with_prefix(prefix: str) -> dict:
+    """Returns {name: value} for every cached entry whose name starts with
+    prefix, e.g. all encrypted_owner_key_v* entries cached per vault key
+    version by KeyBackup/shared_key_flow.py."""
+    secrets_file = _get_secrets_file()
+
+    if os.path.exists(secrets_file):
+        with open(secrets_file, 'r') as file:
+            try:
+                data = json.load(file)
+            except json.JSONDecodeError:
+                return {}
+            return {name: value for name, value in data.items() if name.startswith(prefix)}
+    return {}
+
+
 def set_cached_value(name: str, value: str):
     secrets_file = _get_secrets_file()
 

--- a/KeyBackup/response_parser.py
+++ b/KeyBackup/response_parser.py
@@ -14,25 +14,23 @@ def _transform_to_byte_array(json_object):
 
 def get_fmdn_shared_key(vault_keys):
     json_object = json.loads(vault_keys)
-    processed_data = {}
 
-    # Iterate through the keys in the JSON object
     for key in json_object:
         if key == "finder_hw":
             json_array = json_object[key]
-            array_list2 = []
+            if not json_array:
+                continue
 
-            # Iterate through the JSON array
-            for item in json_array:
-                epoch = item["epoch"]
-                key_data = item["key"]
-
-                processed_key = _transform_to_byte_array(key_data)
-                array_list2.append({"epoch": epoch, "key": processed_key})
-
-                return processed_key
-
-            processed_data[key] = array_list2
+            # Google's vault can hold multiple key generations ("epochs") for this
+            # security domain if the account's FMDN owner key was ever rotated -
+            # always take the newest one instead of whichever entry the array lists
+            # first, or a stale/rotated-out epoch gets used and every decrypt against
+            # current device data fails forever (see NovaApi's owner-key-version
+            # mismatch error). The old code here unconditionally returned after the
+            # first array entry and never compared epochs at all.
+            latest = max(json_array, key=lambda item: int(item["epoch"]))
+            print(f"[ResponseParser] Selected vault key epoch {latest['epoch']} (of {len(json_array)} available).")
+            return _transform_to_byte_array(latest["key"])
 
     raise Exception("No suitable key found in the vault keys.")
 

--- a/KeyBackup/shared_key_flow.py
+++ b/KeyBackup/shared_key_flow.py
@@ -3,12 +3,18 @@
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
 
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as ec
+import json
+import time
 
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support import expected_conditions as ec
+from selenium.webdriver.support.ui import WebDriverWait
+
+from chrome_driver import create_driver
 from KeyBackup.response_parser import get_fmdn_shared_key
 from KeyBackup.shared_key_request import get_security_domain_request_url
-from chrome_driver import create_driver
+
+SIGN_IN_WAIT_S = 300
 
 def request_shared_key_flow():
     driver = create_driver()
@@ -17,9 +23,19 @@ def request_shared_key_flow():
         driver.get("https://accounts.google.com/")
 
         # Wait for user to sign in and redirect to https://myaccount.google.com
-        WebDriverWait(driver, 300).until(
-            ec.url_contains("https://myaccount.google.com")
-        )
+        print(f"[SharedKeyFlow] Waiting up to {SIGN_IN_WAIT_S}s for you to sign in...")
+        try:
+            WebDriverWait(driver, SIGN_IN_WAIT_S).until(
+                ec.url_contains("https://myaccount.google.com")
+            )
+        except TimeoutException:
+            # Selenium's own TimeoutException carries no message - give this
+            # a clear one instead, same as Auth/auth_flow.py's sign-in wait.
+            raise TimeoutError(
+                f"Timed out after {SIGN_IN_WAIT_S}s waiting for you to sign in to your "
+                f"Google account for the encryption confirmation step. Run this again "
+                f"to retry."
+            ) from None
         print("[SharedKeyFlow] Signed in successfully.")
 
         # Open the security domain request URL
@@ -41,33 +57,45 @@ def request_shared_key_flow():
         """
         driver.execute_script(script)
 
-        while True:
+        # This used to be an unconditional "while True" whose except-block
+        # swallowed every exception (not just "no alert yet"), so if
+        # neither JS callback ever fired it hung forever with no way out
+        # short of killing the process by hand. Bound it to the same
+        # sign-in timeout used above instead.
+        print(f"[SharedKeyFlow] Waiting up to {SIGN_IN_WAIT_S}s for the encryption confirmation...")
+        deadline = time.monotonic() + SIGN_IN_WAIT_S
+        while time.monotonic() < deadline:
             # Check for alerts indicating JavaScript calls
             try:
                 WebDriverWait(driver, 0.5).until(ec.alert_is_present())
-                alert = driver.switch_to.alert
-                message = alert.text
-                alert.accept()
+            except TimeoutException:
+                continue  # no alert yet - keep polling until the deadline
 
-                # Parse the alert message
-                import json
+            alert = driver.switch_to.alert
+            message = alert.text
+            alert.accept()
+
+            try:
                 data = json.loads(message)
+            except ValueError:
+                print(f"[SharedKeyFlow] Ignoring unparseable alert: {message!r}")
+                continue
 
-                if data['method'] == 'setVaultSharedKeys':
-                    shared_key = get_fmdn_shared_key(data['vaultKeys'])
-                    print("[SharedKeyFlow] Received Shared Key.")
-                    driver.quit()
-                    return shared_key.hex()
-                elif data['method'] == 'closeView':
-                    print("[SharedKeyFlow] closeView() called. Closing browser.")
-                    driver.quit()
-                    break
+            if data.get('method') == 'setVaultSharedKeys':
+                shared_key = get_fmdn_shared_key(data['vaultKeys'])
+                print("[SharedKeyFlow] Received Shared Key.")
+                return shared_key.hex()
+            elif data.get('method') == 'closeView':
+                raise RuntimeError(
+                    "Google closed the encryption confirmation without providing a key "
+                    "(it may have been cancelled, or failed on Google's side). Run this "
+                    "again to retry."
+                )
 
-            except Exception:
-                pass
-
-    except Exception as e:
-        print(f"An error occurred: {e}")
+        raise TimeoutError(
+            f"Timed out after {SIGN_IN_WAIT_S}s waiting for the encryption confirmation "
+            f"step to complete. Run this again to retry."
+        )
     finally:
         driver.quit()
 

--- a/KeyBackup/shared_key_flow.py
+++ b/KeyBackup/shared_key_flow.py
@@ -10,9 +10,11 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
+from Auth.token_cache import set_cached_value
 from chrome_driver import create_driver
 from KeyBackup.response_parser import get_fmdn_shared_key
 from KeyBackup.shared_key_request import get_security_domain_request_url
+from KeyBackup.vault_web_api import fetch_vault_keys_via_web_app
 
 SIGN_IN_WAIT_S = 300
 
@@ -37,6 +39,23 @@ def request_shared_key_flow():
                 f"to retry."
             ) from None
         print("[SharedKeyFlow] Signed in successfully.")
+
+        # Best-effort: also pull every owner key version via the same internal
+        # RPC the real Find My Device web app uses (see KeyBackup/vault_web_api.py).
+        # GetEidInfoForE2eeDevices (the endpoint the rest of this codebase uses)
+        # always hands back only its own idea of "current", regardless of what
+        # version is requested - this is the only way found so far to reach
+        # the others. Each entry is itself still encrypted with the account's
+        # one stable shared key (confirmed empirically: decrypting one with
+        # get_shared_key() reproduces the exact owner key already cached from
+        # the normal flow), so cache the raw blobs now and unwrap them lazily
+        # wherever get_shared_key() is actually available - see
+        # SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py's
+        # get_owner_key_from_wrapped_blob(). Any failure here is non-fatal to
+        # sign-in; the unlock-page flow below is still the primary path.
+        for entry in fetch_vault_keys_via_web_app(driver):
+            if entry["domain"] == "finder_hw":
+                set_cached_value(f"encrypted_owner_key_v{entry['version']}", entry["key"].hex())
 
         # Open the security domain request URL
         security_url = get_security_domain_request_url()

--- a/KeyBackup/vault_web_api.py
+++ b/KeyBackup/vault_web_api.py
@@ -1,0 +1,130 @@
+#
+#  GoogleFindMyTools - A set of tools to interact with the Google Find My API
+#  Copyright © 2024 Leon Böttger. All rights reserved.
+#
+"""Fetches the account's FMDN vault keys (every version it currently holds)
+via the same internal "batchexecute" RPC the real Find My Device web app
+(google.com/android/find) uses, instead of the more limited
+accounts.google.com/encryption/unlock/android page KeyBackup/shared_key_flow.py
+otherwise talks to - which only ever hands back a single key with no version
+tag at all, discovered by comparing a real browser capture of the web app
+against what this tool receives. Runs entirely inside an already-authenticated
+Selenium session so it rides on that session's own cookies, exactly like the
+real web app does - no separate auth of our own needed.
+"""
+
+import base64
+import json
+
+from selenium.webdriver.support.ui import WebDriverWait
+
+FIND_MY_DEVICE_URL = "https://www.google.com/android/find/?login=&device=1&rs=1"
+
+# window.WIZ_global_data (embedded in the page's own HTML) carries everything
+# needed to call its "batchexecute" RPC framework ourselves: FdrFJe is the
+# session id (f.sid), cfb2h is the build label (bl), and SNlM0e is the
+# anti-CSRF token (at) every POST to it must include.
+_FETCH_SCRIPT = """
+const callback = arguments[arguments.length - 1];
+(async () => {
+    try {
+        const g = window.WIZ_global_data;
+        const params = new URLSearchParams({
+            "rpcids": "FAvFKc",
+            "source-path": "/android/find/",
+            "f.sid": g.FdrFJe,
+            "bl": g.cfb2h,
+            "hl": "en-GB",
+            "_reqid": String(Math.floor(Math.random() * 900000) + 100000),
+            "rt": "c",
+        });
+        const body = new URLSearchParams({
+            "f.req": JSON.stringify([[["FAvFKc", "[]", null, "generic"]]]),
+            "at": g.SNlM0e,
+        });
+        const resp = await fetch(
+            "https://www.google.com/android/find/_/BoqWebFindMyDeviceUi/data/batchexecute?" + params.toString(),
+            {
+                method: "POST",
+                headers: {"Content-Type": "application/x-www-form-urlencoded;charset=utf-8", "X-Same-Domain": "1"},
+                body: body.toString(),
+                credentials: "include",
+            }
+        );
+        callback({ok: resp.ok, status: resp.status, text: await resp.text()});
+    } catch (e) {
+        callback({ok: false, error: String(e)});
+    }
+})();
+"""
+
+
+def _parse_batchexecute_response(text: str) -> list[dict]:
+    """Parses Google's "batchexecute" wire format: an XSSI-protection
+    )]}'  prefix, then repeated <declared-length>\\n<json chunk>\\n blocks.
+    The declared length is unreliable in practice (observed off by a
+    character against the real chunk boundary in a live capture - possibly a
+    byte- vs char-counting quirk on Google's end) so it's used only as an
+    approximate starting point; json.JSONDecoder.raw_decode() finds the real
+    end of the valid JSON from there regardless, then parsing continues right
+    after whatever it actually consumed."""
+    if text.startswith(")]}'"):
+        text = text[4:]
+    text = text.lstrip("\n")
+
+    decoder = json.JSONDecoder()
+    pos, n = 0, len(text)
+    while pos < n:
+        newline = text.find("\n", pos)
+        if newline == -1 or not text[pos:newline].isdigit():
+            break
+        chunk_start = newline + 1
+
+        try:
+            envelope, consumed = decoder.raw_decode(text, chunk_start)
+        except ValueError:
+            break
+        pos = consumed
+        if pos < n and text[pos] == "\n":
+            pos += 1
+
+        for item in envelope:
+            if isinstance(item, list) and len(item) >= 3 and item[0] == "wrb.fr" and item[1] == "FAvFKc":
+                payload = item[2]
+                if not payload:
+                    return []
+                inner = json.loads(payload)
+                entries = inner[0][5]
+                return [
+                    {"key": base64.b64decode(key_b64), "version": version, "domain": domain, "epoch": epoch}
+                    for key_b64, version, domain, epoch, *_rest in entries
+                ]
+    return []
+
+
+def fetch_vault_keys_via_web_app(driver) -> list[dict]:
+    """Returns every {key, version, domain, epoch} entry the account's vault
+    currently holds, using the browser session that just completed the
+    Google sign-in. Best-effort: returns [] on any failure instead of
+    raising, since this is a supplementary data source, not the primary one -
+    a failure here should never fail the sign-in flow itself."""
+    try:
+        driver.get(FIND_MY_DEVICE_URL)
+        WebDriverWait(driver, 30).until(
+            lambda d: d.execute_script(
+                "return !!(window.WIZ_global_data && window.WIZ_global_data.SNlM0e)"
+            )
+        )
+
+        result = driver.execute_async_script(_FETCH_SCRIPT)
+        if not result or not result.get("ok"):
+            print(f"[VaultWebApi] Vault key fetch failed: {result}")
+            return []
+
+        entries = _parse_batchexecute_response(result["text"])
+        print(f"[VaultWebApi] Fetched {len(entries)} vault key(s): "
+              f"{[(e['domain'], e['version'], e['epoch']) for e in entries]}")
+        return entries
+    except Exception as e:
+        print(f"[VaultWebApi] Vault key fetch failed (non-fatal): {e}")
+        return []

--- a/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -6,6 +6,7 @@
 import datetime
 import hashlib
 
+from Auth.token_cache import get_cached_values_with_prefix
 from FMDNCrypto.foreign_tracker_cryptor import decrypt
 from KeyBackup.cloud_key_decryptor import decrypt_eik, decrypt_aes_gcm
 from NovaApi.ExecuteAction.LocateTracker.decrypted_location import WrappedLocation
@@ -16,7 +17,7 @@ from ProtoDecoders.decoder import parse_device_update_protobuf
 from SpotApi.CreateBleDevice.config import mcu_fast_pair_model_id
 from SpotApi.CreateBleDevice.util import flip_bits
 from SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import get_eid_info
-from SpotApi.GetEidInfoForE2eeDevices.get_owner_key import get_owner_key
+from SpotApi.GetEidInfoForE2eeDevices.get_owner_key import get_owner_key, get_owner_key_from_wrapped_blob
 
 
 def create_google_maps_link(latitude, longitude):
@@ -44,27 +45,56 @@ def retrieve_identity_key(device_registration: DeviceRegistration) -> bytes:
     encrypted_identity_key = flip_bits(
         encrypted_user_secrets.encryptedIdentityKey,
         is_mcu)
-    owner_key = get_owner_key()
 
     try:
-        identity_key = decrypt_eik(owner_key, encrypted_identity_key)
-        return identity_key
-    except Exception as e:
+        return decrypt_eik(get_owner_key(), encrypted_identity_key)
+    except Exception:
+        pass  # current owner key didn't decrypt this tracker's identity key - try the next fallback
 
-        e2eeData = get_eid_info()
-        current_owner_key_version = e2eeData.encryptedOwnerKeyAndMetadata.ownerKeyVersion
+    # The account-level "current" owner key (owner_key_version=-1) didn't decrypt
+    # this tracker's identity key - retry by asking explicitly for the version the
+    # tracker's own data says it needs, instead of trusting whatever "-1" happened
+    # to resolve to. An account can have trackers on more than one owner key
+    # generation; see SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py.
+    needed_version = encrypted_user_secrets.ownerKeyVersion
+    try:
+        return decrypt_eik(get_owner_key(owner_key_version=needed_version), encrypted_identity_key)
+    except Exception:
+        pass  # that version didn't work either - try the last-resort fallback below
 
-        print("")
-        print("-" * 40)
-        print("Attention:")
-        print("-" * 40)
+    # Last resort: GetEidInfoForE2eeDevices always hands back its own idea of
+    # "current" regardless of which version we ask it for (both attempts
+    # above confirmed that empirically) - so try every owner-key blob fetched
+    # directly from the real Find My Device web app's own API during sign-in
+    # instead (see KeyBackup/vault_web_api.py). Each is still encrypted with
+    # this account's one stable shared key; verified that unwrapping the
+    # "current" version's blob this way reproduces the exact owner key the
+    # normal path above already derives, so the same unwrap applied to every
+    # other cached version is expected to yield each of those real keys too.
+    for name, blob_hex in get_cached_values_with_prefix("encrypted_owner_key_v").items():
+        try:
+            owner_key = get_owner_key_from_wrapped_blob(bytes.fromhex(blob_hex))
+            identity_key = decrypt_eik(owner_key, encrypted_identity_key)
+            print(f"[DecryptLocations] Decrypted using {name}.")
+            return identity_key
+        except Exception:
+            continue
 
-        if encrypted_user_secrets.ownerKeyVersion < current_owner_key_version:
-            print(f"Failed to decrypt E2EE data. This tracker was encrypted with owner key version {encrypted_user_secrets.ownerKeyVersion}, but the current owner key version is {current_owner_key_version}.\nThis happens if you reset your end-to-end-encrypted data in the past.\nThe tracker cannot be decrypted anymore, and it is recommended to remove it in the Find My Device app.")
-            exit(1)
-        else:
-            print(f"Failed to decrypt identity key encrypted with owner key version {encrypted_user_secrets.ownerKeyVersion}, current owner key version is {current_owner_key_version}.\nThis may happen if you reset your end-to-end-encrypted data. To resolve this issue, open the folder 'Auth' and delete the file 'secrets.json'.")
-            exit(1)
+    e2eeData = get_eid_info()
+    current_owner_key_version = e2eeData.encryptedOwnerKeyAndMetadata.ownerKeyVersion
+
+    print("")
+    print("-" * 40)
+    print("Attention:")
+    print("-" * 40)
+
+    if encrypted_user_secrets.ownerKeyVersion < current_owner_key_version:
+        print(f"Failed to decrypt E2EE data. This tracker was encrypted with owner key version {encrypted_user_secrets.ownerKeyVersion}, but the current owner key version is {current_owner_key_version}.\nThis happens if you reset your end-to-end-encrypted data in the past.\nThe tracker cannot be decrypted anymore, and it is recommended to remove it in the Find My Device app.")
+        exit(1)
+    else:
+        tried_versions = ", ".join(sorted(get_cached_values_with_prefix("encrypted_owner_key_v").keys())) or "none cached"
+        print(f"Failed to decrypt identity key encrypted with owner key version {encrypted_user_secrets.ownerKeyVersion}, current owner key version is {current_owner_key_version}. Also retried by explicitly requesting owner key version {needed_version}, and by trying every vault key version fetched from the Find My Device web app during sign-in ({tried_versions}) - all failed to decrypt.\nThis may happen if the cached owner key is stale (e.g. after re-doing the Google sign-in). To resolve this issue, remove the 'owner_key' entry from 'Auth/secrets.json' so it gets re-derived, or delete the whole file to sign in again from scratch.")
+        exit(1)
 
 
 def decrypt_location_response_locations(device_update_protobuf):

--- a/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -3,8 +3,7 @@
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
 
-import asyncio
-import time
+import threading
 
 from Auth.fcm_receiver import FcmReceiver
 from NovaApi.ExecuteAction.LocateTracker.decrypt_locations import decrypt_location_response_locations
@@ -30,12 +29,14 @@ def create_location_request(canonic_device_id, fcm_registration_id, request_uuid
     return hex_payload
 
 
-def get_location_data_for_device(canonic_device_id, name):
+def get_location_data_for_device(canonic_device_id, name, timeout=60):
 
     print(f"[LocationRequest] Requesting location data for {name}...")
 
     result = None
+    received = threading.Event()
     request_uuid = generate_random_uuid()
+    receiver = FcmReceiver()
 
     def handle_location_response(response):
         nonlocal result
@@ -43,18 +44,26 @@ def get_location_data_for_device(canonic_device_id, name):
 
         if device_update.fcmMetadata.requestUuid == request_uuid:
             print("[LocationRequest] Location request successful. Decrypting locations...")
-            result = parse_device_update_protobuf(response)
+            result = device_update
             #print_device_update_protobuf(response)
+            received.set()
 
-    fcm_token = FcmReceiver().register_for_location_updates(handle_location_response)
+    fcm_token = receiver.register_for_location_updates(handle_location_response)
 
-    hex_payload = create_location_request(canonic_device_id, fcm_token, request_uuid)
-    nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
+    try:
+        hex_payload = create_location_request(canonic_device_id, fcm_token, request_uuid)
+        nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
 
-    while result is None:
-        time.sleep(0.1)
+        # Google's push doesn't always come back (device offline, no fresh fix
+        # available, etc.) - this used to poll forever with no way out, hanging
+        # the whole script until it was killed by hand.
+        if not received.wait(timeout=timeout):
+            print(f"[LocationRequest] Timed out after {timeout}s waiting for {name}.")
+            return
 
-    decrypt_location_response_locations(result)
+        decrypt_location_response_locations(result)
+    finally:
+        receiver.unregister_callback(handle_location_response)
 
 if __name__ == '__main__':
     get_location_data_for_device(get_example_data("sample_canonic_device_id"), "Test")

--- a/NovaApi/nova_request.py
+++ b/NovaApi/nova_request.py
@@ -32,7 +32,15 @@ def nova_request(api_scope, hex_payload):
         return response.content.hex()
     else:
         soup = BeautifulSoup(response.text, 'html.parser')
-        print("[NovaRequest] Error: ", soup.get_text())
+        error_text = soup.get_text().strip()
+        print("[NovaRequest] Error: ", error_text)
+        # Every caller either discards this return value or waits on some
+        # other side effect of the request actually arriving (e.g. an FCM
+        # push for a locate action). Silently returning None here made a
+        # rejected request indistinguishable from "accepted, but nothing
+        # ever came back", forcing callers to burn a full timeout before
+        # reporting a failure that was already known immediately.
+        raise RuntimeError(f"Nova request to {api_scope} failed with {response.status_code}: {error_text}")
 
 
 if __name__ == '__main__':

--- a/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
+++ b/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
@@ -6,9 +6,15 @@ from ProtoDecoders import Common_pb2
 from ProtoDecoders import DeviceUpdate_pb2
 from SpotApi.spot_request import spot_request
 
-def get_eid_info():
+def get_eid_info(owner_key_version: int = -1):
+    # owner_key_version=-1 (the default) asks for whatever the account-level
+    # endpoint considers "current" - which, for accounts with more than one
+    # owner key generation in play, isn't reliably the version a *specific*
+    # tracker's own data actually needs. Pass the tracker's own
+    # encryptedUserSecrets.ownerKeyVersion here to ask for that version
+    # explicitly instead of guessing.
     get_eid_info_for_e2ee_devices_request = Common_pb2.GetEidInfoForE2eeDevicesRequest()
-    get_eid_info_for_e2ee_devices_request.ownerKeyVersion = -1
+    get_eid_info_for_e2ee_devices_request.ownerKeyVersion = owner_key_version
     get_eid_info_for_e2ee_devices_request.hasOwnerKeyVersion = True
 
     serialized_request = get_eid_info_for_e2ee_devices_request.SerializeToString()

--- a/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -9,21 +9,44 @@ from KeyBackup.cloud_key_decryptor import decrypt_owner_key
 from KeyBackup.shared_key_retrieval import get_shared_key
 from SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import get_eid_info
 
-def _retrieve_owner_key() -> str:
-    eid_info = get_eid_info()
+def _retrieve_owner_key(owner_key_version: int) -> str:
+    eid_info = get_eid_info(owner_key_version)
     shared_key = get_shared_key()
 
     encrypted_owner_key = eid_info.encryptedOwnerKeyAndMetadata.encryptedOwnerKey
     owner_key = decrypt_owner_key(shared_key, encrypted_owner_key)
-    owner_key_version = eid_info.encryptedOwnerKeyAndMetadata.ownerKeyVersion
+    returned_version = eid_info.encryptedOwnerKeyAndMetadata.ownerKeyVersion
 
-    print(f"Retrieved owner key with version: {owner_key_version}")
+    print(f"Retrieved owner key with version: {returned_version}")
 
     return owner_key.hex()
 
 
-def get_owner_key() -> bytes:
-    return unhexlify(get_cached_value_or_set('owner_key', _retrieve_owner_key))
+def get_owner_key_from_wrapped_blob(encrypted_owner_key: bytes) -> bytes:
+    """Decrypts a specific owner-key blob (e.g. one fetched for a particular
+    version via KeyBackup/vault_web_api.py, since GetEidInfoForE2eeDevices
+    always hands back only its own idea of "current" regardless of what
+    version is requested - confirmed empirically, see
+    NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py's retry chain)
+    using the account's one stable shared key. Verified against this account:
+    decrypting the "current" version's blob this way reproduces the exact
+    owner key GetEidInfoForE2eeDevices's own default path already derives, so
+    the same operation applied to a *different* version's blob is expected to
+    yield that version's real owner key instead of guessing at request
+    parameters the server evidently ignores."""
+    return decrypt_owner_key(get_shared_key(), encrypted_owner_key)
+
+
+def get_owner_key(owner_key_version: int = -1) -> bytes:
+    # -1 (the default) means "whatever the account-level endpoint considers
+    # current" - kept under the original flat 'owner_key' cache key for
+    # backward compatibility. A specific version is cached separately, since
+    # an account can have trackers on more than one owner key generation and
+    # a single flat slot can only ever remember one answer (see
+    # NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py, which retries
+    # with a specific version on a decrypt failure).
+    cache_key = "owner_key" if owner_key_version == -1 else f"owner_key_v{owner_key_version}"
+    return unhexlify(get_cached_value_or_set(cache_key, lambda: _retrieve_owner_key(owner_key_version)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #22 & https://github.com/leonboe1/GoogleFindMyTools/issues/67.

**Raise on failed Nova API requests instead of returning None**
A failed request used to just print an error and return `None`. Every caller either discards that return value or waits on some other side effect of the request arriving (like an FCM push for a locate action), so a rejected request was indistinguishable from one that was accepted but never got a response - callers had to sit through a full timeout before finding out something had already failed immediately.

**Time out location requests instead of polling forever**
`get_location_data_for_device()` used to spin in a tight sleep loop with no way out if Google's push never arrived (device offline, no fresh fix available, etc.), hanging the script until it got killed by hand. Gives it a 60s default timeout instead, and unregisters the callback afterwards so repeated calls don't leak entries into `FcmReceiver`'s callback list forever.

**Fix FCM push listener crashes and hanging sign-in waits**
- Per-message crypto-key/salt headers sometimes come without base64url padding, crashing the listener with a padding error.
- Those same headers can carry more than one `;`-separated parameter, which used to decode into a garbage blob instead of raising, failing later with a confusing EC key error deep inside `http_ece`.
- A data message meant for a different app on the same Android ID used to be decrypted anyway (guaranteed to fail) and crash the whole listener - now it's skipped.
- Selenium's `TimeoutException` has no message, so a sign-in timeout showed up as a blank error - both sign-in waits now raise a descriptive `TimeoutError`.
- Overlapping sign-in flows would kill each other's Chrome process (`create_driver()` unconditionally pkills chrome before launching) - serialized with a lock.
- The encryption-confirmation alert-polling loop was unconditional (`while True`) with a bare `except` that swallowed everything, so it could hang forever if neither JS callback ever fired - bounded to the same sign-in timeout.

**Fix decrypt failures after an E2EE owner key rotation** 
This is the `cryptography.exceptions.InvalidTag` / "Failed to decrypt identity key encrypted with owner key version X, current owner key version is Y" failure. Two separate bugs combined to make trackers permanently undecryptable after an account's FMDN owner key was ever rotated (or on any account with more than one owner key generation in play), even when a working key was actually available:
- The vault can hold more than one key epoch for the `finder_hw` domain, but the parser always returned whichever entry the array happened to list first instead of comparing epochs.
- On a decrypt failure, `decrypt_locations.py` went straight to telling the user to delete their credentials and sign in again, without ever retrying against the tracker's own required owner key version, or against any other version the account might have.

Now it retries with the tracker's own required version, then as a last resort against every owner key blob pulled from the real Find My Device web app's own internal API during sign-in (`KeyBackup/vault_web_api.py`, new - `GetEidInfoForE2eeDevices` always hands back only its own idea of "current" no matter what version is actually requested, so this is the only way found so far to reach the others). Only falls through to the delete-and-resignin message if all of those fail too.
