### PR TITLE
Store credentials as YAML with optional encryption at rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.idea
 /DULT/OwnerLookup/Results
 /Auth/secrets.json
+/Auth/auth.yaml
 /example_data.json
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,xcode,swift,swiftpackagemanager,objective-c

--- a/Auth/token_cache.py
+++ b/Auth/token_cache.py
@@ -3,14 +3,79 @@
 #  Copyright © 2024 Leon Böttger. All rights reserved.
 #
 
+import base64
+import hashlib
 import json
 import os
 
 import yaml
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 SECRETS_FILE = 'auth.yaml'
 # Pre-YAML location - _migrate_from_legacy_json() reads this once, then never again.
 LEGACY_SECRETS_FILE = 'secrets.json'
+
+# Marks a value in auth.yaml as AES-256-GCM encrypted (see _encrypt/_decrypt
+# below) - versioned so a future change to the scheme can tell old and new
+# values apart. Anything not carrying this prefix is read back as-is, so
+# values written before SECRETS_ENCRYPTION_KEY was ever set (or with it
+# unset) keep working without any migration step.
+_ENC_PREFIX = "gfmtenc1:"
+
+_warned_unencrypted = False
+
+
+def _encryption_key() -> bytes | None:
+    """Every value in auth.yaml is encrypted with this key when set (any
+    string - hashed down to an AES-256 key, so there's no fixed-length/
+    encoding requirement on what the user puts in the env var) - see
+    _encrypt/_decrypt. Unset or empty means what it always meant: values are
+    stored as plain YAML, same as before this existed."""
+    raw = os.environ.get("SECRETS_ENCRYPTION_KEY")
+    if not raw:
+        return None
+    return hashlib.sha256(raw.encode()).digest()
+
+
+def _warn_if_unencrypted():
+    global _warned_unencrypted
+    if _warned_unencrypted or _encryption_key() is not None:
+        return
+    _warned_unencrypted = True
+    print(f"[TokenCache] SECRETS_ENCRYPTION_KEY is not set - credentials in {_get_secrets_file()} "
+          f"(OAuth tokens, FCM credentials, vault keys, ...) are stored in plain text on disk. "
+          f"Set SECRETS_ENCRYPTION_KEY to encrypt them at rest.")
+
+
+def _encrypt(value):
+    """value can be any JSON-able type (a plain string, or fcm_credentials'
+    nested dict) - serialized to JSON before encrypting so this isn't just
+    for flat strings."""
+    key = _encryption_key()
+    if key is None:
+        return value
+    plaintext = json.dumps(value).encode()
+    nonce = os.urandom(12)
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
+    return _ENC_PREFIX + base64.b64encode(nonce + ciphertext).decode()
+
+
+def _decrypt(value):
+    key = _encryption_key()
+    if key is None or not isinstance(value, str) or not value.startswith(_ENC_PREFIX):
+        return value  # not encrypted (no key configured, or predates one being set)
+    try:
+        blob = base64.b64decode(value[len(_ENC_PREFIX):])
+        nonce, ciphertext = blob[:12], blob[12:]
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+        return json.loads(plaintext)
+    except (InvalidTag, ValueError):
+        # Wrong/rotated SECRETS_ENCRYPTION_KEY, or corrupt data - treat as
+        # missing rather than crashing every caller of get_cached_value.
+        print(f"[TokenCache] Could not decrypt a value from {_get_secrets_file()} - wrong SECRETS_ENCRYPTION_KEY?")
+        return None
+
 
 def get_cached_value_or_set(name: str, generator: callable):
 
@@ -25,13 +90,15 @@ def get_cached_value_or_set(name: str, generator: callable):
 
 
 def get_cached_value(name: str):
-    value = _load().get(name)
+    _warn_if_unencrypted()
+    value = _decrypt(_load().get(name))
     return value if value else None
 
 
 def set_cached_value(name: str, value):
+    _warn_if_unencrypted()
     data = _load(strict=True)
-    data[name] = value
+    data[name] = _encrypt(value)
     _save(data)
 
 
@@ -53,10 +120,11 @@ def _load(strict: bool = False) -> dict:
 
 def _migrate_from_legacy_json() -> dict | None:
     """One-time upgrade path from the pre-YAML secrets.json - read it once,
-    write it straight back out as auth.yaml, and leave the old file in place
-    untouched (as a backup, and so a downgrade isn't a hard break). Every
-    load after that first migration hits the YAML file directly and never
-    looks at the JSON file again."""
+    write it straight back out as auth.yaml (encrypting each value if
+    SECRETS_ENCRYPTION_KEY is set, same as any other write), and leave the
+    old file in place untouched (as a backup, and so a downgrade isn't a
+    hard break). Every load after that first migration hits the YAML file
+    directly and never looks at the JSON file again."""
     legacy_file = os.path.join(os.path.dirname(_get_secrets_file()), LEGACY_SECRETS_FILE)
     if not os.path.exists(legacy_file):
         return None
@@ -67,7 +135,8 @@ def _migrate_from_legacy_json() -> dict | None:
             return None
     if not isinstance(data, dict):
         return None
-    _save(data)
+    encrypted = {name: _encrypt(value) for name, value in data.items()}
+    _save(encrypted)
     return data
 
 

--- a/Auth/token_cache.py
+++ b/Auth/token_cache.py
@@ -6,7 +6,11 @@
 import json
 import os
 
-SECRETS_FILE = 'secrets.json'
+import yaml
+
+SECRETS_FILE = 'auth.yaml'
+# Pre-YAML location - _migrate_from_legacy_json() reads this once, then never again.
+LEGACY_SECRETS_FILE = 'secrets.json'
 
 def get_cached_value_or_set(name: str, generator: callable):
 
@@ -21,34 +25,55 @@ def get_cached_value_or_set(name: str, generator: callable):
 
 
 def get_cached_value(name: str):
-    secrets_file = _get_secrets_file()
-
-    if os.path.exists(secrets_file):
-        with open(secrets_file, 'r') as file:
-            try:
-                data = json.load(file)
-                value = data.get(name)
-                if value:
-                    return value
-            except json.JSONDecodeError:
-                return None
-    return None
+    value = _load().get(name)
+    return value if value else None
 
 
-def set_cached_value(name: str, value: str):
-    secrets_file = _get_secrets_file()
-
-    if os.path.exists(secrets_file):
-        with open(secrets_file, 'r') as file:
-            try:
-                data = json.load(file)
-            except json.JSONDecodeError:
-                raise Exception("Could not read secrets file. Aborting.")
-    else:
-        data = {}
+def set_cached_value(name: str, value):
+    data = _load(strict=True)
     data[name] = value
-    with open(secrets_file, 'w') as file:
-        json.dump(data, file)
+    _save(data)
+
+
+def _load(strict: bool = False) -> dict:
+    secrets_file = _get_secrets_file()
+    if os.path.exists(secrets_file):
+        with open(secrets_file, 'r') as file:
+            try:
+                data = yaml.safe_load(file)
+            except yaml.YAMLError:
+                if strict:
+                    # A write is about to happen - refuse rather than silently
+                    # start from {} and clobber whatever's actually in there.
+                    raise Exception("Could not read secrets file. Aborting.") from None
+                return {}
+        return data if isinstance(data, dict) else {}
+    return _migrate_from_legacy_json() or {}
+
+
+def _migrate_from_legacy_json() -> dict | None:
+    """One-time upgrade path from the pre-YAML secrets.json - read it once,
+    write it straight back out as auth.yaml, and leave the old file in place
+    untouched (as a backup, and so a downgrade isn't a hard break). Every
+    load after that first migration hits the YAML file directly and never
+    looks at the JSON file again."""
+    legacy_file = os.path.join(os.path.dirname(_get_secrets_file()), LEGACY_SECRETS_FILE)
+    if not os.path.exists(legacy_file):
+        return None
+    with open(legacy_file, 'r') as file:
+        try:
+            data = json.load(file)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(data, dict):
+        return None
+    _save(data)
+    return data
+
+
+def _save(data: dict):
+    with open(_get_secrets_file(), 'w') as file:
+        yaml.safe_dump(data, file, sort_keys=False, allow_unicode=True)
 
 
 def _get_secrets_file():

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ On the first run, an authentication sequence is executed, which requires a compu
 
 The authentication results are stored in `Auth/auth.yaml`. If you intend to run this tool on a headless machine, you can just copy this file to avoid having to use Chrome. (If you're upgrading from an older version that still has `Auth/secrets.json`, it's migrated to `auth.yaml` automatically the first time it's read; the old file is left in place, untouched.)
 
+Set the `SECRETS_ENCRYPTION_KEY` environment variable (any string) to encrypt everything in `auth.yaml` at rest (AES-256-GCM) instead of storing it as plain text. Leaving it unset keeps the previous plain-text behavior and prints a one-time warning saying so. Losing or changing this key makes existing encrypted values unreadable; you'd need to sign in again to regenerate them.
+
 ### Known Issues
 - "Your encryption data is locked on your device" is shown if you have never set up Find My Device on an Android device. Solution: Login with your Google Account on an Android device, go to Settings > Google > All Services > Find My Device > Find your offline devices > enable "With network in all areas" or "With network in high-traffic areas only". If "Find your offline devices" is not shown in Settings, you will need to download the Find My Device app from Google's Play Store, and pair a real Find My Device tracker with your device to force-enable the Find My Device network.
 - No support for trackers using the P-256 curve and 32-Byte advertisements. Regular trackers don't seem to use this curve at all - I can only confirm that it is used with Sony's WH1000XM5 headphones.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently, it is possible to query Find My Device / Find Hub trackers and Androi
 
 On the first run, an authentication sequence is executed, which requires a computer with access to Google Chrome.
 
-The authentication results are stored in `Auth/secrets.json`. If you intend to run this tool on a headless machine, you can just copy this file to avoid having to use Chrome.
+The authentication results are stored in `Auth/auth.yaml`. If you intend to run this tool on a headless machine, you can just copy this file to avoid having to use Chrome. (If you're upgrading from an older version that still has `Auth/secrets.json`, it's migrated to `auth.yaml` automatically the first time it's read; the old file is left in place, untouched.)
 
 ### Known Issues
 - "Your encryption data is locked on your device" is shown if you have never set up Find My Device on an Android device. Solution: Login with your Google Account on an Android device, go to Settings > Google > All Services > Find My Device > Find your offline devices > enable "With network in all areas" or "With network in high-traffic areas only". If "Find your offline devices" is not shown in Settings, you will need to download the Find My Device app from Google's Play Store, and pair a real Find My Device tracker with your device to force-enable the Find My Device network.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ gpsoauth>=1.1.1
 requests>=2.32.3
 beautifulsoup4>=4.12.3
 pyscrypt>=1.6.2
+pyyaml>=6.0.2
 cryptography>=43.0.3
 pycryptodomex>=3.21.0
 ecdsa>=0.19.0


### PR DESCRIPTION
Two commits:

**Store credentials as YAML instead of JSON**
`Auth/secrets.json` becomes `Auth/auth.yaml`. An existing `secrets.json` is migrated automatically the first time it's read - written straight back out as `auth.yaml`, with the old file left in place untouched (as a backup, and so a downgrade isn't a hard break). Every load after that first migration hits the YAML file directly and never looks at the JSON file again.

No behavior change for callers - `get_cached_value`/`set_cached_value`/`get_cached_value_or_set` keep the same signatures.

**Add optional encryption at rest via `SECRETS_ENCRYPTION_KEY`**
Every value written to `auth.yaml` (OAuth tokens, FCM credentials, vault keys, ...) is encrypted with AES-256-GCM when this env var is set - any string works, it's hashed down to an AES-256 key. Unset keeps the previous plain-text behavior and prints a one-time warning saying so.

Values are JSON-serialized before encrypting so this isn't limited to flat strings (`fcm_credentials` is a nested dict), and prefixed with a versioned marker so an encrypted value is distinguishable from a plain one - anything without the prefix is read back as-is, so values written before a key was ever set keep working with no migration step. A wrong or rotated key makes decrypt fail, which is treated as a missing value (`None`) rather than crashing every caller of `get_cached_value`.

The legacy `secrets.json` migration also encrypts each value on the way in when a key is already set.

No new hard dependency beyond `pyyaml` - `cryptography` (used for the AES-GCM encryption) was already a requirement.
