### PR TITLE
Add GFMT_CHROME_BINARY env var to point at a specific Chrome executable

### DIFF
--- a/chrome_driver.py
+++ b/chrome_driver.py
@@ -10,6 +10,10 @@ import time
 
 def find_chrome():
     """Find Chrome executable using known paths and system commands."""
+    env_path = os.environ.get("GFMT_CHROME_BINARY")
+    if env_path and os.path.exists(env_path):
+        return env_path
+
     possiblePaths = [
         r"C:\Program Files\Google\Chrome\Application\chrome.exe",
         r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",


### PR DESCRIPTION
`find_chrome()` searches a fixed list of common install paths plus `shutil.which()` - reasonable defaults, but no way to override them if Chrome lives somewhere else (a non-standard install location, a portable build, a container image with Chrome baked in at a custom path). The current failure message even says as much: "If you know that Chrome is installed, update Chrome to the latest version. If the script is still not working, set the path to your Chrome executable manually inside the script" - which today means editing `chrome_driver.py` by hand.

Setting `GFMT_CHROME_BINARY` to an existing file path short-circuits the search and uses that path directly, so that's now an env var instead of a code edit. Related reports where this would have helped point people toward a manual path override without one being available: #4, #69, #106 (not fixes for those specific underlying failures - #106 in particular is a chromedriver/Chrome version mismatch, unrelated to path detection - just cases where "Chrome isn't where the script expects it" or "let me just point at the exact binary" came up).
